### PR TITLE
Improved MacOS container run instructions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       # build and push Docker image to dockerhub.    
       - run: 
           name: Build and push

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ But nothing is keeping you from doing it yourself.
 `docker run --rm -it --user $(id -u) -e DISPLAY=unix$DISPLAY --workdir=$(pwd) --volume="/home/$USER:/home/$USER" --volume="/etc/group:/etc/group:ro" --volume="/etc/passwd:/etc/passwd:ro" --volume="/etc/shadow:/etc/shadow:ro" --volume="/etc/sudoers.d:/etc/sudoers.d:ro" -v /tmp/.X11-unix:/tmp/.X11-unix grindrodbank/pgmodeler`
 
 ### macOS
-You need XQuartz installed.
+You need XQuartz installed, and 'Allow connections from network clients' selected in the X11 preferences.
 
 Run the following two commands:
 

--- a/README.md
+++ b/README.md
@@ -79,14 +79,19 @@ But nothing is keeping you from doing it yourself.
 `docker run --rm -it --user $(id -u) -e DISPLAY=unix$DISPLAY --workdir=$(pwd) --volume="/home/$USER:/home/$USER" --volume="/etc/group:/etc/group:ro" --volume="/etc/passwd:/etc/passwd:ro" --volume="/etc/shadow:/etc/shadow:ro" --volume="/etc/sudoers.d:/etc/sudoers.d:ro" -v /tmp/.X11-unix:/tmp/.X11-unix grindrodbank/pgmodeler`
 
 ### macOS
-You need XQuartz running and you need your ip: `ipconfig en0` or `ipconfig en1`. Use one of these commands to get your IP.
+You need XQuartz installed.
 
-Export it ```export MY_IP=`ipconfig en0` ```
+Run the following two commands:
 
-To run it:
+```bash
+xhost + 127.0.0.1 
+```
 
-`docker run --rm -it --user $(id -u) -e DISPLAY=$MY_IP --workdir=$(pwd) --volume="/User/$USER:/home/$USER" --volume="/etc/group:/etc/group:ro" --volume="/etc/passwd:/etc/passwd:ro" --volume="/etc/shadow:/etc/shadow:ro" --volume="/etc/sudoers.d:/etc/sudoers.d:ro" -v /tmp/.X11-unix:/tmp/.X11-unix grindrodbank/pgmodeler`
+```bash
+docker run --rm -it -e DISPLAY=host.docker.internal:0 --workdir=$(pwd) -v /Users/{your_user_folder}:/home/{your_user_folder} --volume="/etc/group:/etc/group:ro" --volume="/etc/passwd:/etc/passwd:ro" --volume="/etc/sudoers.d:/etc/sudoers.d:ro" -v /tmp/.X11-unix:/tmp/.X11-unix -v $(pwd):$(pwd) grindrodbank/pgmodeler
+```
 
+***Note**: Replace {your_user_folder} with the literal name of your home folder. Do not use the $USER variable.*
 
 ## License
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FGrindrodBank%2Fpgmodeler-x11.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2FGrindrodBank%2Fpgmodeler-x11?ref=badge_large)


### PR DESCRIPTION
This PR updates the macOS run instructions to allow the correct run of PG Modeler in Docker on the latest macOS.

This fixes #18.